### PR TITLE
Heroku push preparation: config cloudinary in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
J'ai mis "cloudinary" dans la config de production. C'est nécessaire pour qu'on ait aussi les images cloudinary sur HEROKU en prod.