### PR TITLE
improved tools controller

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -90,7 +90,7 @@ class ToolsController < ApplicationController
   end
 
   def filter_tools
-    tools = Tool.all
+    tools = Tool.where.not(user: current_user)
     tools = tools.where("name ILIKE ?", "%#{search_params[:query]}%") unless search_params[:query].blank?
     tools = tools.where("category ILIKE ?", "%#{search_params[:category]}%") unless search_params[:category].blank?
     tools = tools.where("daily_price < ?", search_params[:max_price]) unless search_params[:max_price].blank?


### PR DESCRIPTION
Un owner ne voit plus ses propres outils dans l'index des outils
Exemple: Florent ne voit que les outils d'Adrien et Jérôme
![image](https://user-images.githubusercontent.com/93684799/155702138-2b35d0bd-ff73-4d76-bbc0-cb8370bc8594.png)
